### PR TITLE
Using stats.html to report total number of messages

### DIFF
--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -7,16 +7,35 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.codeu.data.Datastore;
+import com.google.gson.JsonObject;
+
 /**
- * Responds with a hard-coded message for testing purposes.
+ * Handles fetching site statistics.
  */
 @WebServlet("/stats")
 public class StatsPageServlet extends HttpServlet{
   
+ private Datastore datastore;
+
+ @Override
+ public void init() {
+  datastore = new Datastore();
+ }
+
+ /**
+  * Responds with site statistics in JSON.
+  */
  @Override
  public void doGet(HttpServletRequest request, HttpServletResponse response)
    throws IOException {
   
-  response.getOutputStream().println("hello world");
+  response.setContentType("application/json");
+
+  int messageCount = datastore.getTotalMessageCount();
+
+  JsonObject jsonObject = new JsonObject();
+  jsonObject.addProperty("messageCount", messageCount);
+  response.getOutputStream().println(jsonObject.toString());
  }
 }

--- a/src/main/webapp/js/stats-loader.js
+++ b/src/main/webapp/js/stats-loader.js
@@ -1,0 +1,24 @@
+// Fetch stats and display them in the page.
+function fetchStats(){
+  const url = '/stats';
+  fetch(url).then((response) => {
+    return response.json();
+  }).then((stats) => {
+    const statsContainer = document.getElementById('stats-container');
+    statsContainer.innerHTML = '';
+
+    const messageCountElement = buildStatElement('Message count: ' + stats.messageCount);
+    statsContainer.appendChild(messageCountElement);
+  });
+}
+
+function buildStatElement(statString){
+ const statElement = document.createElement('p');
+ statElement.appendChild(document.createTextNode(statString));
+ return statElement;
+}
+
+// Fetch data and populate the UI of the page.
+function buildUI(){
+ fetchStats();
+}

--- a/src/main/webapp/stats.html
+++ b/src/main/webapp/stats.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Stats</title>
+  <link rel="stylesheet" href="/css/main.css">
+  <script src="/js/stats-loader.js"></script>
+</head>
+<body onload="buildUI()">
+<div id="content">
+  <h1>Site Statistics</h1>
+  <hr/>
+  <div id="stats-container">Loading...</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Modified stats page servlet to return the total number of messages as JSON. Created a stats.html page and stats-loader.js script to report the total number of messages in a more user-friendly format.