### PR TITLE
Added Markdown functionality to messages feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@ limitations under the License.
       <version>1.52.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.atlassian.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
+      <version>0.12.1</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -29,6 +29,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
+/** Atlassian commonmark library for converting Markdown to HTML */
+import org.commonmark.node.*;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
 
 /** Handles fetching and saving {@link Message} instances. */
 @WebServlet("/messages")
@@ -78,7 +82,14 @@ public class MessageServlet extends HttpServlet {
     String user = userService.getCurrentUser().getEmail();
     String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
 
-    Message message = new Message(user, text);
+    // Converts markdown tags to HTML tags
+    Parser parser = Parser.builder().build();
+    Node doc = parser.parse(text);
+    HtmlRenderer rend = HtmlRenderer.builder().build(); 
+    String markedText = rend.render(doc);
+
+
+    Message message = new Message(user, markedText);
     datastore.storeMessage(message);
 
     response.sendRedirect("/user-page.html?user=" + user);


### PR DESCRIPTION
Modified MessageServlet.java so that after the doPost method removed all HTML tags from a processed message, Markdown tags would be translated into HTML tags, allowing basic Markdown use on the messages.