### PR TITLE
Allowed styling message text with HTML and text toolbar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@ limitations under the License.
       <version>0.12.1</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>ckeditor</artifactId>
+      <version>4.7.2</version>
+    </dependency> 
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -81,7 +81,7 @@ public class MessageServlet extends HttpServlet {
 
     String user = userService.getCurrentUser().getEmail();
     // String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
-    String userText = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+    String userText = Jsoup.clean(request.getParameter("text"), Whitelist.basicWithImages());
     
     String regex = "(https?://\\S+\\.(png|jpg))";
     String replacement = "<img src=\"$1\" />";

--- a/src/main/webapp/user-page.html
+++ b/src/main/webapp/user-page.html
@@ -22,6 +22,7 @@ limitations under the License.
     <link rel="stylesheet" href="/css/main.css">
     <link rel="stylesheet" href="/css/user-page.css">
     <script src="/js/user-page-loader.js"></script>
+    <script src="http://cdn.ckeditor.com/4.7.2/basic/ckeditor.js"></script>
   </head>
   <body onload="buildUI();">
     <nav>
@@ -54,6 +55,10 @@ limitations under the License.
       <input type="submit" value="Submit">
     </form>
     <hr/>
+
+    <script>
+        CKEDITOR.replace('text');
+    </script>
 
     <div id="message-container">Loading...</div>
     <nav>


### PR DESCRIPTION
Changed MessageServlet class's whitelist to allow basic HTML tags and image tags. Changed user-page.html to replace its text input box with a formatted stylized text box that allows **bold** and _italic_ writing, among other things. 